### PR TITLE
Remap function indices in wrappers

### DIFF
--- a/src/interrogatedb/interrogateFunctionWrapper.cxx
+++ b/src/interrogatedb/interrogateFunctionWrapper.cxx
@@ -74,6 +74,7 @@ input(istream &in) {
  */
 void InterrogateFunctionWrapper::
 remap_indices(const IndexRemapper &remap) {
+  _function = remap.map_from(_function);
   _return_value_destructor = remap.map_from(_return_value_destructor);
   _return_type = remap.map_from(_return_type);
 


### PR DESCRIPTION
This resolves an issue where `interrogatedb.interrogate_wrapper_function` would return the wrong value.